### PR TITLE
Fix ignored Hostname config

### DIFF
--- a/zabbix-agent2/run.sh
+++ b/zabbix-agent2/run.sh
@@ -8,7 +8,7 @@ ZABBIX_HOSTNAME=$(jq --raw-output ".hostname" "$CONFIG_PATH")
 # Update zabbix-agent config
 ZABBIX_CONFIG_FILE=/etc/zabbix/zabbix_agent2.conf
 sed -i 's#^\(Server\(Active\)\?\)=.*#\1='"${ZABBIX_SERVER}"'#' "$ZABBIX_CONFIG_FILE"
-sed -i 's/^\(Hostname\)=.*/\1='"${ZABBIX_HOSTNAME}"'/' "$ZABBIX_CONFIG_FILE"
+sed -i 's/^#\?\s\?\(Hostname\)=.*$/\1='"${ZABBIX_HOSTNAME}"'/' "${ZABBIX_CONFIG_FILE}"
 
 # Run zabbix-agent2 in foreground
 exec su zabbix -s /bin/ash -c "zabbix_agent2 -f"


### PR DESCRIPTION
Hi !

Hostname might be commented out in the stock config file, preventing the parameter to be applied, and thus preventing ActiveChecks to run :
```
28753:20201003:110553.019 cannot send list of active checks to "x.x.x.x": host [fd74094e-zabbix-agent2] not found
```

Updated the regex to take it into account.

Thanks a lot for creating this addon, very useful ! :)