### PR TITLE
[zabbix-agent2] Fix regex

### DIFF
--- a/zabbix-agent2/run.sh
+++ b/zabbix-agent2/run.sh
@@ -7,7 +7,7 @@ ZABBIX_HOSTNAME=$(jq --raw-output ".hostname" "$CONFIG_PATH")
 
 # Update zabbix-agent config
 ZABBIX_CONFIG_FILE=/etc/zabbix/zabbix_agent2.conf
-sed -i 's/^#\?\s?\(Server\(Active\)\?\)=.*/\1='"${ZABBIX_SERVER}"'/' "$ZABBIX_CONFIG_FILE"
+sed -i 's@^#\?\s\?\(Server\(Active\)\?\)=.*@\1='"${ZABBIX_SERVER}"'@' "$ZABBIX_CONFIG_FILE"
 sed -i 's/^#\?\s\?\(Hostname\)=.*$/\1='"${ZABBIX_HOSTNAME}"'/' "${ZABBIX_CONFIG_FILE}"
 
 # Run zabbix-agent2 in foreground


### PR DESCRIPTION
Hi !

- One of the question marks was not escaped
- Used `@` as a regex separator so the variable can contain slashes (as per your initial commit 1a31e71c153f36689163f9dc6f4a3ec5cbafcdc8)

Cheers, and again, thanks for this addon !