### PR TITLE
Update Dockerfile

### DIFF
--- a/flicd/Dockerfile
+++ b/flicd/Dockerfile
@@ -9,7 +9,8 @@ LABEL maintainer "Philipp Schmitt <philipp@schmitt.co>"
 RUN case $(arch) in \
         x86_64|amd64) export ARCH=x86_64 ;; \
         i386) export ARCH=i386 ;; \
-        armv6l|armv7l|aarch64) export ARCH=armv6l ;; \
+        armv6l|armv7l) export ARCH=armv6l ;; \
+        aarch64) export ARCH=aarch64 ;; \
     esac && \
     apt-get update && \
     apt-get install -y git && \


### PR DESCRIPTION
Updated Dockerfile to support Aarch64 in the fliclib-linux-hci repo