### PR TITLE
Disable apparmor for pilight - Fixes #19

### DIFF
--- a/pilight/config.json
+++ b/pilight/config.json
@@ -10,6 +10,7 @@
   "description": "Pilight server",
   "startup": "services",
   "boot": "auto",
+  "apparmor": "false",
   "devices": [
     "/dev/mem:/dev/mem:rw"
   ],


### PR DESCRIPTION
This fixes the permission denied error when starting pilight as described in #19 