### PR TITLE
false init

### DIFF
--- a/zabbix-agent/config.json
+++ b/zabbix-agent/config.json
@@ -2,6 +2,7 @@
   "name": "zabbix-agent",
   "version": "1.3",
   "slug": "zabbix-agent",
+  "init": "false",
   "description": "Zabbix agent",
   "arch": [
     "armhf",

--- a/zabbix-agent2/config.json
+++ b/zabbix-agent2/config.json
@@ -2,6 +2,7 @@
   "name": "zabbix-agent2",
   "version": "1.1",
   "slug": "zabbix-agent2",
+  "init": "false",
   "description": "Zabbix agent 2",
   "arch": [
     "armhf",


### PR DESCRIPTION
Changes in latet HA makes it so zabbix starts with error:
s6-overlay-suexec: fatal: can only run as pid 1

This is the solution accodring to release docs.


My branch has been tested and the agent works.