### PR TITLE
Zabbix Agent 2 - MongoDB / PostgreSQL Plugin enablement

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,11 @@ jobs:
             arch: amd64
           - addon: picamera
             arch: i386
+          - addon: zabbix-agent2
+            arch: i386
+          - addon: zabbix-agent2
+            arch: armhf
+
     steps:
       - name: Checkout repo
         uses: actions/checkout@master

--- a/zabbix-agent2/CHANGELOG.md
+++ b/zabbix-agent2/CHANGELOG.md
@@ -1,3 +1,13 @@
+# [1.5] - 2023-07-10
+
+## Added
+
+- Zabbix Agent 2 plugins for PostgreSQL and MongoDB
+
+### Removed
+
+- Due to the addition of the Zabbix Agent 2 plugins i386 and armhf support had to be removed
+
 # [1.4] - 2023-07-09
 
 ## Changed

--- a/zabbix-agent2/Dockerfile
+++ b/zabbix-agent2/Dockerfile
@@ -1,7 +1,10 @@
-FROM alpine
-
 ARG BUILD_ARCH
 ARG BUILD_VERSION
+ARG BUILD_BASE_IMAGE=zabbix/zabbix-agent2:alpine-latest
+
+FROM ${BUILD_BASE_IMAGE} as builder
+
+FROM alpine
 
 LABEL maintainer "Philipp Schmitt <philipp@schmitt.co>"
 
@@ -12,6 +15,10 @@ RUN apk add --no-cache jq zabbix-agent2 && \
     addgroup -g 1003 docker && \
     addgroup zabbix docker && \
     mkdir -p /etc/zabbix/zabbix_agent2.d/plugins.d
+
+# Copy zabbix-agent2 plugins
+COPY --from=builder ["/usr/sbin/zabbix-agent2-plugin", "/usr/sbin/zabbix-agent2-plugin"]
+RUN echo -e "\nPlugins.PostgreSQL.System.Path=/usr/sbin/zabbix-agent2-plugin/zabbix-agent2-plugin-mongodb\nPlugins.PostgreSQL.System.Path=/usr/sbin/zabbix-agent2-plugin/zabbix-agent2-plugin-postgresql\n" >> /etc/zabbix/zabbix_agent2.conf
 
 # Copy data for add-on
 COPY run.sh /


### PR DESCRIPTION
As mentioned in #63, this change unfortunately has the need to remove the arches i386 and armhf, i386 could be recovered if the executables are gathered from the bigger zabbix/zabbix-build-mysql:alpine-latest container.
armhf seems not to be built anywhere at all. (might also need to mark the container image entries in Docker Hub as orphaned/archived)

This is basically the same process as the Zabbix team is doing it for their own images as well,
I looked if there are any plans to build the executables directly for alpine, but didn't see any, so this might be the best path to the the support!

As well again, if anything should be changed improved or if this is not how you would like to have it implemented, I of course can look for a solution.

Cheers!