### PR TITLE
Refactor Zabbix Agent / Zabbix Agent 2 add-ons

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Home Assistant addons by Philipp Schmitt
 
-Add to Home Assistant using the repository url: 
+Add to Home Assistant using the repository url:
 https://github.com/pschmitt/home-assistant-addons
 
 ## flicd
@@ -15,7 +15,7 @@ React to flic button presses on the Raspberry Pi.
 
 The flicd server needs a bluetooth controller. If you are running [Hass.io based on HassOS](https://www.home-assistant.io/blog/2018/07/11/hassio-images/), you can use the built-in controller. If you are running the older [Hass.io based on ResinOS](https://www.home-assistant.io/blog/2018/07/11/hassio-images/), you'll need to install the [Bluetooth BCM43xx](https://www.home-assistant.io/addons/bluetooth_bcm43xx/) add-on.
 
-```
+```text
 Available HCI devices found:
 hci0
 Trying hci0
@@ -27,7 +27,7 @@ Initialization of Bluetooth controller done!
 
 By default, flicd is going to use `hci0` bluetooth controller. If you have multiple bluetooth controllers you can configure flicd to use another controller by specifying it in `hci_dev` configuration setting of the add-on.
 
-```
+```json
 {
   "hci_dev": "hci1"
 }
@@ -63,7 +63,12 @@ Expose your raspicam.
 
 [Tailscale](https://tailscale.com) VPN service. This addon was originally published [here](https://github.com/tsujamin/hass-addons/tree/main/tailscale).
 
-## zabbix-agent{,2}
+## Zabbix Agent
 
-Zabbix agent{,2}.
+Uses zabbix-agent package from current alpine version.
 
+## Zabbix Agent 2
+
+Uses zabbix-agent2 package from current alpine version, also includes PostgreSQL and MongoDB plug-ins.
+
+To access docker api it is necessary to disable protection mode.

--- a/zabbix-agent/CHANGELOG.md
+++ b/zabbix-agent/CHANGELOG.md
@@ -1,3 +1,9 @@
+# [1.6.0] - 2025-01-11
+
+## Changed
+
+- Drop unnecessary permissions
+
 # [1.5] - 2023-07-09
 
 ## Changed

--- a/zabbix-agent/CHANGELOG.md
+++ b/zabbix-agent/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Drop unnecessary permissions
 
+## Added
+
+- Add configurable UserParameter option
+
 # [1.5] - 2023-07-09
 
 ## Changed

--- a/zabbix-agent/Dockerfile
+++ b/zabbix-agent/Dockerfile
@@ -3,7 +3,10 @@ FROM alpine
 ARG BUILD_ARCH
 ARG BUILD_VERSION
 
-LABEL maintainer "Philipp Schmitt <philipp@schmitt.co>"
+LABEL org.opencontainers.image.authors="Philipp Schmitt <philipp@schmitt.co>, Lukas Magauer <lukas@magauer.eu>" \
+      org.opencontainers.image.url="https://github.com/pschmitt/home-assistant-addons/tree/main/zabbix-agent" \
+      org.opencontainers.image.title="Zabbix Agent image for Home Assistant Add-on" \
+      org.opencontainers.image.base.name="alpine"
 
 ENV LANG C.UTF-8
 

--- a/zabbix-agent/README.md
+++ b/zabbix-agent/README.md
@@ -1,0 +1,3 @@
+## Zabbix Agent
+
+Uses zabbix-agent package from current alpine version.

--- a/zabbix-agent/config.json
+++ b/zabbix-agent/config.json
@@ -1,8 +1,8 @@
 {
-  "name": "zabbix-agent",
-  "version": "1.5",
+  "name": "Zabbix Agent Home Assistant add-on",
+  "version": "1.6.0",
   "slug": "zabbix-agent",
-  "description": "Zabbix agent",
+  "description": "Uses zabbix-agent package from current alpine version",
   "url": "https://github.com/pschmitt/home-assistant-addons/tree/main/zabbix-agent",
   "arch": [
     "armhf",
@@ -13,11 +13,7 @@
   ],
   "startup": "system",
   "boot": "auto",
-  "full_access": true,
   "host_ipc": true,
-  "host_pid": true,
-  "host_network": true,
-  "docker_api": true,
   "ports": {
     "10050/tcp": 10050
   },

--- a/zabbix-agent/config.json
+++ b/zabbix-agent/config.json
@@ -28,6 +28,7 @@
     "serveractive": "str",
     "hostname": "str",
     "tlspskidentity": "str?",
-    "tlspsksecret": "str?"
+    "tlspsksecret": "str?",
+    "userparameter": "str?"
   }
 }

--- a/zabbix-agent/config.json
+++ b/zabbix-agent/config.json
@@ -1,8 +1,8 @@
 {
-  "name": "Zabbix Agent Home Assistant add-on",
+  "name": "Zabbix Agent",
   "version": "1.6.0",
   "slug": "zabbix-agent",
-  "description": "Uses zabbix-agent package from current alpine version",
+  "description": "Zabbix Network Monitoring Agent",
   "url": "https://github.com/pschmitt/home-assistant-addons/tree/main/zabbix-agent",
   "arch": [
     "armhf",

--- a/zabbix-agent/run.sh
+++ b/zabbix-agent/run.sh
@@ -29,7 +29,7 @@ unset ZABBIX_TLSPSK_IDENTITY
 unset ZABBIX_TLSPSK_SECRET
 
 if [ ${ZABBIX_USERPARAMETER} != "null" ]; then
-  sed -i 's@^#\?\s\?\(UserParameter\)=.*@\1='"${ZABBIX_USERPARAMETER}"'@' "${ZABBIX_CONFIG_FILE}"
+  sed -i 's@^#\?\s\?\(UserParameter\)=.*@\1='"${ZABBIX_USER_PARAMETER}"'@' "${ZABBIX_CONFIG_FILE}"
 fi
 
 # Run zabbix-agent in foreground

--- a/zabbix-agent/run.sh
+++ b/zabbix-agent/run.sh
@@ -8,7 +8,7 @@ ZABBIX_SERVER_ACTIVE=$(jq --raw-output ".serveractive" "${CONFIG_PATH}")
 ZABBIX_HOSTNAME=$(jq --raw-output ".hostname" "${CONFIG_PATH}")
 ZABBIX_TLSPSK_IDENTITY=$(jq --raw-output ".tlspskidentity" "${CONFIG_PATH}")
 ZABBIX_TLSPSK_SECRET=$(jq --raw-output ".tlspsksecret" "${CONFIG_PATH}")
-ZABBIX_USERPARAMETER=$(jq --raw-output ".userparameter" "${CONFIG_PATH}")
+ZABBIX_USER_PARAMETER=$(jq --raw-output ".userparameter" "${CONFIG_PATH}")
 
 # Update zabbix-agent config
 ZABBIX_CONFIG_FILE=/etc/zabbix/zabbix_agentd.conf

--- a/zabbix-agent/run.sh
+++ b/zabbix-agent/run.sh
@@ -8,6 +8,7 @@ ZABBIX_SERVER_ACTIVE=$(jq --raw-output ".serveractive" "${CONFIG_PATH}")
 ZABBIX_HOSTNAME=$(jq --raw-output ".hostname" "${CONFIG_PATH}")
 ZABBIX_TLSPSK_IDENTITY=$(jq --raw-output ".tlspskidentity" "${CONFIG_PATH}")
 ZABBIX_TLSPSK_SECRET=$(jq --raw-output ".tlspsksecret" "${CONFIG_PATH}")
+ZABBIX_USERPARAMETER=$(jq --raw-output ".userparameter" "${CONFIG_PATH}")
 
 # Update zabbix-agent config
 ZABBIX_CONFIG_FILE=/etc/zabbix/zabbix_agentd.conf
@@ -26,6 +27,10 @@ if [ "${ZABBIX_TLSPSK_IDENTITY}" != "null" ] && [ "${ZABBIX_TLSPSK_SECRET}" != "
 fi
 unset ZABBIX_TLSPSK_IDENTITY
 unset ZABBIX_TLSPSK_SECRET
+
+if [ ${ZABBIX_USERPARAMETER} != "null" ]; then
+  sed -i 's@^#\?\s\?\(UserParameter\)=.*@\1='"${ZABBIX_USERPARAMETER}"'@' "${ZABBIX_CONFIG_FILE}"
+fi
 
 # Run zabbix-agent in foreground
 exec su zabbix -s /bin/ash -c "zabbix_agentd -f"

--- a/zabbix-agent/translations/en.yaml
+++ b/zabbix-agent/translations/en.yaml
@@ -1,0 +1,24 @@
+---
+configuration:
+  server:
+    name: Server
+    description: >-
+      A list of comma-delimited IP addresses, optionally in CIDR notation,
+      or DNS names of Zabbix servers and Zabbix proxies.
+  serveractive:
+    name: ServerActive
+    description: The Zabbix server/proxy address or cluster configuration to get active checks from.
+  hostname:
+    name: Hostname
+    description: A parameter that defines the hostname.
+  tlspskidentity:
+    name: TLSPSKIdentity
+    description: The pre-shared key identity string, used for encrypted communications with Zabbix server.
+  tlspsksecret:
+    name: TLSPSKSecret
+    description: The pre-shared key string, used for encrypted communications with Zabbix server.
+  userparameter:
+    name: UserParameter
+    description: A user-defined parameter to monitor. Currently only one UserParameter possible.
+network:
+  10050/tcp: Listening port for passive monitoring.

--- a/zabbix-agent2/CHANGELOG.md
+++ b/zabbix-agent2/CHANGELOG.md
@@ -1,3 +1,13 @@
+# [1.7.0] - 2025-01-11
+
+## Fixed
+
+- Use correct permissions for docker socket
+
+## Changed
+
+- Drop unnecessary permissions
+
 # [1.6.0] - 2025-01-10
 
 ## Changed

--- a/zabbix-agent2/CHANGELOG.md
+++ b/zabbix-agent2/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 - Drop unnecessary permissions
 
+## Added
+
+- Add configurable UserParameter option
+
 # [1.6.0] - 2025-01-10
 
 ## Changed

--- a/zabbix-agent2/Dockerfile
+++ b/zabbix-agent2/Dockerfile
@@ -6,13 +6,16 @@ FROM ${BUILD_BASE_IMAGE} as builder
 
 FROM alpine
 
-LABEL maintainer "Philipp Schmitt <philipp@schmitt.co>"
+LABEL org.opencontainers.image.authors="Philipp Schmitt <philipp@schmitt.co>, Lukas Magauer <lukas@magauer.eu>" \
+      org.opencontainers.image.url="https://github.com/pschmitt/home-assistant-addons/tree/main/zabbix-agent2" \
+      org.opencontainers.image.title="Zabbix Agent 2 image for Home Assistant Add-on" \
+      org.opencontainers.image.base.name="alpine"
 
 ENV LANG C.UTF-8
 
 # Install requirements for add-on
 RUN apk add --no-cache jq zabbix-agent2 && \
-    addgroup -g 1003 docker && \
+    addgroup -g 102 docker && \
     addgroup zabbix docker && \
     mkdir -p /etc/zabbix/zabbix_agent2.d/plugins.d
 

--- a/zabbix-agent2/README.md
+++ b/zabbix-agent2/README.md
@@ -1,0 +1,5 @@
+## Zabbix Agent 2
+
+Uses zabbix-agent2 package from current alpine version, also includes PostgreSQL and MongoDB plug-ins.
+
+To access docker api it is necessary to disable protection mode.

--- a/zabbix-agent2/config.json
+++ b/zabbix-agent2/config.json
@@ -1,8 +1,8 @@
 {
-  "name": "Zabbix Agent 2 Home Assistant add-on",
+  "name": "Zabbix Agent 2",
   "version": "1.7.0",
   "slug": "zabbix-agent2",
-  "description": "Uses zabbix-agent2 package from current alpine version, also includes PostgreSQL and MongoDB plug-ins. To access docker api it is necessary to disable protection mode",
+  "description": "Zabbix Network Monitoring Agent 2",
   "url": "https://github.com/pschmitt/home-assistant-addons/tree/main/zabbix-agent2",
   "arch": [
     "aarch64",

--- a/zabbix-agent2/config.json
+++ b/zabbix-agent2/config.json
@@ -26,6 +26,7 @@
     "serveractive": "str",
     "hostname": "str",
     "tlspskidentity": "str?",
-    "tlspsksecret": "str?"
+    "tlspsksecret": "str?",
+    "userparameter": "str?"
   }
 }

--- a/zabbix-agent2/config.json
+++ b/zabbix-agent2/config.json
@@ -1,22 +1,16 @@
 {
-  "name": "zabbix-agent2",
-  "version": "1.6.0",
+  "name": "Zabbix Agent 2 Home Assistant add-on",
+  "version": "1.7.0",
   "slug": "zabbix-agent2",
-  "description": "Zabbix agent 2",
+  "description": "Uses zabbix-agent2 package from current alpine version, also includes PostgreSQL and MongoDB plug-ins. To access docker api it is necessary to disable protection mode",
   "url": "https://github.com/pschmitt/home-assistant-addons/tree/main/zabbix-agent2",
   "arch": [
-    "armhf",
-    "armv7",
     "aarch64",
-    "amd64",
-    "i386"
+    "amd64"
   ],
   "startup": "system",
   "boot": "auto",
-  "full_access": true,
   "host_ipc": true,
-  "host_pid": true,
-  "host_network": true,
   "docker_api": true,
   "ports": {
     "10050/tcp": 10050

--- a/zabbix-agent2/run.sh
+++ b/zabbix-agent2/run.sh
@@ -29,7 +29,7 @@ unset ZABBIX_TLSPSK_IDENTITY
 unset ZABBIX_TLSPSK_SECRET
 
 if [ ${ZABBIX_USERPARAMETER} != "null" ]; then
-  sed -i 's@^#\?\s\?\(UserParameter\)=.*@\1='"${ZABBIX_USERPARAMETER}"'@' "${ZABBIX_CONFIG_FILE}"
+  sed -i 's@^#\?\s\?\(UserParameter\)=.*@\1='"${ZABBIX_USER_PARAMETER}"'@' "${ZABBIX_CONFIG_FILE}"
 fi
 
 # Run zabbix-agent2 in foreground

--- a/zabbix-agent2/run.sh
+++ b/zabbix-agent2/run.sh
@@ -8,6 +8,7 @@ ZABBIX_SERVER_ACTIVE=$(jq --raw-output ".serveractive" "${CONFIG_PATH}")
 ZABBIX_HOSTNAME=$(jq --raw-output ".hostname" "${CONFIG_PATH}")
 ZABBIX_TLSPSK_IDENTITY=$(jq --raw-output ".tlspskidentity" "${CONFIG_PATH}")
 ZABBIX_TLSPSK_SECRET=$(jq --raw-output ".tlspsksecret" "${CONFIG_PATH}")
+ZABBIX_USERPARAMETER=$(jq --raw-output ".userparameter" "${CONFIG_PATH}")
 
 # Update zabbix-agent config
 ZABBIX_CONFIG_FILE=/etc/zabbix/zabbix_agent2.conf
@@ -26,6 +27,10 @@ if [ "${ZABBIX_TLSPSK_IDENTITY}" != "null" ] && [ "${ZABBIX_TLSPSK_SECRET}" != "
 fi
 unset ZABBIX_TLSPSK_IDENTITY
 unset ZABBIX_TLSPSK_SECRET
+
+if [ ${ZABBIX_USERPARAMETER} != "null" ]; then
+  sed -i 's@^#\?\s\?\(UserParameter\)=.*@\1='"${ZABBIX_USERPARAMETER}"'@' "${ZABBIX_CONFIG_FILE}"
+fi
 
 # Run zabbix-agent2 in foreground
 exec su zabbix -s /bin/ash -c "zabbix_agent2 -f"

--- a/zabbix-agent2/run.sh
+++ b/zabbix-agent2/run.sh
@@ -8,7 +8,7 @@ ZABBIX_SERVER_ACTIVE=$(jq --raw-output ".serveractive" "${CONFIG_PATH}")
 ZABBIX_HOSTNAME=$(jq --raw-output ".hostname" "${CONFIG_PATH}")
 ZABBIX_TLSPSK_IDENTITY=$(jq --raw-output ".tlspskidentity" "${CONFIG_PATH}")
 ZABBIX_TLSPSK_SECRET=$(jq --raw-output ".tlspsksecret" "${CONFIG_PATH}")
-ZABBIX_USERPARAMETER=$(jq --raw-output ".userparameter" "${CONFIG_PATH}")
+ZABBIX_USER_PARAMETER=$(jq --raw-output ".userparameter" "${CONFIG_PATH}")
 
 # Update zabbix-agent config
 ZABBIX_CONFIG_FILE=/etc/zabbix/zabbix_agent2.conf

--- a/zabbix-agent2/translations/en.yaml
+++ b/zabbix-agent2/translations/en.yaml
@@ -1,0 +1,24 @@
+---
+configuration:
+  server:
+    name: Server
+    description: >-
+      A list of comma-delimited IP addresses, optionally in CIDR notation,
+      or DNS names of Zabbix servers and Zabbix proxies.
+  serveractive:
+    name: ServerActive
+    description: The Zabbix server/proxy address or cluster configuration to get active checks from.
+  hostname:
+    name: Hostname
+    description: A parameter that defines the hostname.
+  tlspskidentity:
+    name: TLSPSKIdentity
+    description: The pre-shared key identity string, used for encrypted communications with Zabbix server.
+  tlspsksecret:
+    name: TLSPSKSecret
+    description: The pre-shared key string, used for encrypted communications with Zabbix server.
+  userparameter:
+    name: UserParameter
+    description: A user-defined parameter to monitor. Currently only one UserParameter possible.
+network:
+  10050/tcp: Listening port for passive monitoring.


### PR DESCRIPTION
Hi Philipp,

As already mentioned in the issues I took a closer look at the builds now,
so I ended up refactoring the add-ons a bit beside fixing/adding functionality.

Means this PR does the following things:
- Update the README to better tell what the add-ons do
- Zabbix Agent:
  - Dropped a whole lot of permissions as I didn't see any need for these (after tests)
  - Added the UserParameter option
- Zabbix Agent 2:
  - Dropped a few permissions here too but less, as some more is needed for functionality
  - Added the UserParameter option
  - Fixed the docker groups gid, must have changed at some point
- You will also notice that I reworked the Container labels to OCI annotations
- Added translations for the config parameters, this is the description Zabbix has in their docs
- And finally added README's to also drag the top level README into the Home Assistant interface

The annotations thing also made me wonder if it might be time to make it apparent, that I will gladly also commit to do changes in the future too. If you say it's still fully your project and I'm just helping with commits, I'm also fine with taking my name out 🙂 

Please take your time with this PR as it's of course quite a few changes 👍🏻 

Cheers, Lukas

Fixes #70 #76 #83 