### PR TITLE
Zabbix Agent / Zabbix Agent 2 - Fix UserParameter and host network metrics

### DIFF
--- a/zabbix-agent/CHANGELOG.md
+++ b/zabbix-agent/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.6.1] - 2025-01-12
+
+## Fixed
+
+- Fix UserParameter value check
+- To detect host interface metrics container needs to run in host network
+
 # [1.6.0] - 2025-01-11
 
 ## Changed

--- a/zabbix-agent/config.json
+++ b/zabbix-agent/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Zabbix Agent",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "slug": "zabbix-agent",
   "description": "Zabbix Network Monitoring Agent",
   "url": "https://github.com/pschmitt/home-assistant-addons/tree/main/zabbix-agent",
@@ -13,6 +13,7 @@
   ],
   "startup": "system",
   "boot": "auto",
+  "host_network": true,
   "host_ipc": true,
   "ports": {
     "10050/tcp": 10050

--- a/zabbix-agent/run.sh
+++ b/zabbix-agent/run.sh
@@ -28,7 +28,7 @@ fi
 unset ZABBIX_TLSPSK_IDENTITY
 unset ZABBIX_TLSPSK_SECRET
 
-if [ ${ZABBIX_USERPARAMETER} != "null" ]; then
+if [ "${ZABBIX_USER_PARAMETER}" != "null" ]; then
   sed -i 's@^#\?\s\?\(UserParameter\)=.*@\1='"${ZABBIX_USER_PARAMETER}"'@' "${ZABBIX_CONFIG_FILE}"
 fi
 

--- a/zabbix-agent2/CHANGELOG.md
+++ b/zabbix-agent2/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.7.1] - 2025-01-12
+
+## Fixed
+
+- Fix UserParameter value check
+- To detect host interface metrics container needs to run in host network
+
 # [1.7.0] - 2025-01-11
 
 ## Fixed

--- a/zabbix-agent2/config.json
+++ b/zabbix-agent2/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Zabbix Agent 2",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "slug": "zabbix-agent2",
   "description": "Zabbix Network Monitoring Agent 2",
   "url": "https://github.com/pschmitt/home-assistant-addons/tree/main/zabbix-agent2",
@@ -10,6 +10,7 @@
   ],
   "startup": "system",
   "boot": "auto",
+  "host_network": true,
   "host_ipc": true,
   "docker_api": true,
   "ports": {

--- a/zabbix-agent2/run.sh
+++ b/zabbix-agent2/run.sh
@@ -28,7 +28,7 @@ fi
 unset ZABBIX_TLSPSK_IDENTITY
 unset ZABBIX_TLSPSK_SECRET
 
-if [ ${ZABBIX_USERPARAMETER} != "null" ]; then
+if [ "${ZABBIX_USER_PARAMETER}" != "null" ]; then
   sed -i 's@^#\?\s\?\(UserParameter\)=.*@\1='"${ZABBIX_USER_PARAMETER}"'@' "${ZABBIX_CONFIG_FILE}"
 fi
 


### PR DESCRIPTION
Hey Philipp, 

as @rwez pointed out in #88, there happened a small oops in the refactor 🙂 
And beside that after looking for a while at the output in my live system, I noticed that the host network is unfortunately still needed, without that it doesn't see the correct NICs (I would have loved to just give it access to the metrics but this is not possible)

~~Currently testing the fixes, but I'm pretty sure that's it 👍~~
Tested both cases, and now I can confirm full functionality is working (unless I find something again in the next days, sorry for the increased PR amount)

Cheers, Lukas